### PR TITLE
Remove stack yaml single quote escaping

### DIFF
--- a/stack-update.sh
+++ b/stack-update.sh
@@ -56,7 +56,6 @@ existing_env_json="$(echo -n "$stack"|jq ".Env" -jc)"
 dcompose=$(cat "$TARGET_YML")
 dcompose="${dcompose//$'\r'/''}"
 dcompose="${dcompose//$'"'/'\"'}"
-dcompose="${dcompose//$"'"/"\'"}"
 echo "/-----READ_YML--------"
 
 echo "$dcompose"


### PR DESCRIPTION
Otherwise the server answers with this error:
```json
{"err":"Invalid request payload","details":"invalid character '\\'' in string escape code"}
```